### PR TITLE
Extend server api

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -8,6 +8,8 @@ module.exports = {
   host: 'localhost',
   crm: {
     host: MOCK_SERVER,
+    fetchConcurrency: 3,
+    waitForRetry: 3000,
   },
   oms: {
     host: MOCK_SERVER,

--- a/index.js
+++ b/index.js
@@ -4,6 +4,29 @@ const bodyParserMW = require('koa-bodyparser');
 
 const router = require('./lib/routes');
 
+const errorMiddleware = async (ctx, next) => {
+  try {
+    await next()
+  } catch (err) {
+    console.error(err);
+
+    ctx.status = err.status || 500;
+    ctx.set('Content-Type', 'application/json');
+
+    return {
+      success: false,
+      error: err.message,
+      data: null,
+    };
+  } finally {
+    return {
+      success: true,
+      error: null,
+      data: ctx.response.body,
+    }
+  }
+};
+
 const logMiddleware = async (ctx, next) => {
   const start = Date.now();
 
@@ -23,6 +46,7 @@ async function start() {
   app
     .use(logMiddleware)
     .use(bodyParserMW())
+    .use(errorMiddleware)
     .use(router.allowedMethods())
     .use(router.routes())
     .listen(config.get('port'));

--- a/lib/models/api.js
+++ b/lib/models/api.js
@@ -1,0 +1,35 @@
+const axios = require('axios');
+const config = require('config');
+
+const delay = (ms) => new Promise(r => setTimeout(r, ms));
+
+const api = axios.create();
+
+const requestsQueue = [];
+let concurrentRequests = 0;
+
+api.interceptors.request.use(async axiosConfig => {
+  requestsQueue.push(axiosConfig);
+
+  while (concurrentRequests >= config.get('crm.fetchConcurrency')) {
+    console.debug(`Crm concurrent request added to queue`, {queueLength: concurrentRequests});
+
+    await delay(config.get('crm.waitForRetry'))
+  }
+
+  ++concurrentRequests;
+
+  return requestsQueue.shift()
+});
+
+api.interceptors.response.use(response => {
+  --concurrentRequests;
+
+  return response
+}, error => {
+  --concurrentRequests;
+
+  throw error
+});
+
+module.exports = api;

--- a/lib/models/users.js
+++ b/lib/models/users.js
@@ -1,0 +1,95 @@
+const config = require('config');
+
+const api = require('./api');
+const cacheModel = require('../services/cache');
+
+class User {
+  constructor({ id, phone, lastName, firstName, balance }) {
+      this.id = id;
+      this.phone = phone;
+      this.lastName = lastName;
+      this.firstName = firstName;
+      this.balance = balance;
+  }
+
+  async findById(id) {
+    const cache = await cacheModel.findOne({
+      where: {id},
+    });
+
+    if (cache) {
+      return cache
+    }
+
+    const response = await api.request({
+      method: 'GET',
+      url: `https://${config.get('crm.host')}/user`,
+      params: {id}
+    });
+
+    const user = await this.fromResponse(response.data);
+
+    await cacheModel.save(user);
+
+    return user;
+  }
+
+  static async create({phone, lastName, firstName, balance}) {
+    const crmUser = {
+      Phone: phone,
+      Last_Name: lastName,
+      First_Name: firstName,
+      Current_Balance: balance,
+    };
+
+    const response = await api.request({
+      method: 'POST',
+      url: `https://${config.get('crm.host')}/user`,
+      data: [crmUser],
+    });
+
+    return response && response.data
+  }
+
+  static async update({id, phone, lastName, firstName, balance}) {
+    const crmUser = {
+      id,
+      ...phone && {Phone: phone},
+      ...lastName && {Last_Name: lastName},
+      ...firstName && {First_Name: firstName},
+      ...balance && {Current_Balance: balance},
+    };
+
+    const response = await api.request({
+      method: 'PUT',
+      url: `https://${config.get('crm.host')}/user`,
+      data: [crmUser],
+    });
+
+    return response && response.data
+  }
+
+  static async delete(id) {
+    const response = await api.request({
+      method: 'PUT',
+      url: `https://${config.get('crm.host')}/user`,
+      params: {id}
+    });
+
+    return response && response.data
+  }
+
+  static fromResponse(data) {
+    console.debug('Crm User model response: ', {data});
+
+    return new User({
+      id: data.id,
+      phone: data.Phone,
+      lastName: data.Last_Name,
+      firstName: data.First_Name,
+      balance: data.Current_Balance,
+    })
+  }
+}
+
+module.exports = User;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,9 +1,61 @@
 const Router = require('koa-router');
 
+const User = require('./models/users');
+const oms = require('./services/oms');
+const inventory = require('./services/inventory');
+
 const router = new Router();
 
 router.get('/health', (ctx) => {
   return ctx.response.body = 'OK';
+});
+
+router.get('/getUser', async (ctx) => {
+  ctx.response.body = await User.findById(ctx.request.query.id);
+  ctx.status = 200;
+});
+
+router.get('/createUser', async (ctx) => {
+  ctx.response.body = await User.create(ctx.request.query);
+  ctx.status = 200;
+});
+
+router.put('/updateUser', async (ctx) => {
+  await User.update(ctx.request.body);
+  ctx.status = 200;
+});
+
+router.get('/deleteUser', async (ctx) => {
+  await User.delete(ctx.request.query.id);
+  ctx.status = 200;
+});
+
+router.post('/orderWithInvoice', async (ctx) => {
+  const orderData = ctx.request.body;
+
+  const orderId = oms.order.create({
+    ...orderData,
+    status: 'new',
+  });
+
+  const invoiceId = oms.invoice.create(orderData);
+
+  for (let { id, count } of orderData.products) {
+    const product = await inventory.product.getById(id);
+
+    await inventory.product.update({
+      ...product,
+      reserved: product.reserved + count
+    });
+  }
+
+  oms.order.update({
+    ...orderData,
+    status: 'ready',
+  });
+
+  ctx.response.body = { orderId, invoiceId };
+  ctx.status = 200;
 });
 
 module.exports = router;


### PR DESCRIPTION
## For reviewer

Please read PR description and do code review - comment problematic places, propose solutions or just ask questions to the code as you do during usual PR review.

❗ Do not hesitate to comment on anything that creates questions for you or on any problems you could find

❗ You can use Ukrainian, Russian or English, which is more comfortable for you

## Problem

We have respective services as a source of truth:
- `crm` for user data
- `oms` for order data
- `inventory` for products and stock

❗ These services are mocked with single Postman [collection](https://documenter.getpostman.com/view/10954446/SztD46xp?version=latest)

Our server is a public gateway, and we need to extend its functionality with next endpoints:
- CRUD for users records from `crm`
- order checkout endpoint with following actions:
  - create order with status `new` in `oms`
  - create invoice for the new order
  - reserve order products in `inventory` service
  - update order with status `ready`

Please note that `crm` has API limits:
  - number of concurrent requests <= 3, in case of > 3 all our next requests will be blocked for 10 sec
  - throughput <= 1000 requests / day is free, every request over this limit will be additionally charged 50 cents/req

## Solution
To solve API limitation of `crm` I have used global axios [interceptor](https://github.com/axios/axios#interceptors) - to control how many concurrent requests should be sent to `crm`.
To reduce total number of requests to `crm` I am caching users model.
Users API is nice and pretty. This code is ideal and works as expected. No one could comment my code, just approve and deploy.

## Changes
- changed `config/default.js` - added params to handle concurrency limits
- changed `lib/index.js` - added errorMiddleware to ensure that server is not killed in case of failed request
- changed `lib/routes.js` - added API for users and orders
- added `lib/models/api.js` to provide concurrency safe axios version
- added `lib/models/users.js` to work with user entity with cache to reduce `crm` API usage

## Testing
Setup server locally and use requests examples:

1) Get user
```
curl --location --request GET 'http://localhost:3003/getUser?id=1'
```
2) Create user
```
curl --location --request GET 'http://localhost:3003/createUser' \
--header 'Content-Type: application/json' \
--data-raw '{
	"phone": "3806660001",
	"lastName": "Johny",
	"firstName": "Pooper",
	"balance": "666"
}'
```
3) Update user
```
curl --location --request PUT 'http://localhost:3003/updateUser' \
--header 'Content-Type: application/json' \
--data-raw '{
	"id": "123123",
	"phone": "3806660001",
	"lastName": "Johny",
	"firstName": "Pooper",
	"balance": "666"
}'
```
4) Delete user
```
curl --location --request GET 'http://localhost:3003/deleteUser?id=1'
```
5) Create order
```
curl --location --request POST 'http://localhost:3003/orderWithInvoice' \
--header 'Content-Type: application/json' \
--data-raw '{
	"id": "1",
	"code": "4RT6SD",
	"user": {
		"id": "1",
		"name": "Bob"
	},
	"products": [
		{
			"id": "2",
			"count": "4",
			"price": 300
		},{
			"id": "3",
			"count": "5",
			"price": 200
		}
	]
}'
```